### PR TITLE
To assign jobs to jenkins nodes they need a label

### DIFF
--- a/lib/jenkins_cron/job.rb
+++ b/lib/jenkins_cron/job.rb
@@ -1,6 +1,6 @@
 module JenkinsCron
   class Job < Whenever::Job
-    attr_reader :group
+    attr_reader :group, :label
 
     def initialize(options = {})
       super
@@ -8,6 +8,7 @@ module JenkinsCron
       @options[:output] = ''
       @group = @options[:group].try(:to_sym) || nil
       @name  = @options[:name]  || raise(ArgumentError.new("A name is required to create a job at Jenkins!"))
+      @label = @options.fetch(:label, nil)
     end
 
     def name

--- a/lib/jenkins_cron/job_list.rb
+++ b/lib/jenkins_cron/job_list.rb
@@ -34,6 +34,7 @@ module JenkinsCron
           jobs.each_with_index do |job, idx|
             JenkinsCron::Output::PeriodicalTrigger.output(time, job) do |cron|
               config = Jenkins::JobConfigBuilder.new(:none) do |c|
+                c.assigned_node = job.label
                 if group
                   c.triggers = [{:class => :timer, :spec => cron[:time_spec]}] if idx == 0
                 else


### PR DESCRIPTION
This is required to have non-importer jobs run on a different jenkins node
